### PR TITLE
Update app.dart

### DIFF
--- a/packages/at_app/lib/src/bundles/templates/app/app.dart
+++ b/packages/at_app/lib/src/bundles/templates/app/app.dart
@@ -12,8 +12,8 @@ class AppTemplateBundle extends AtTemplateBundle<AtTemplateVars> {
 final AtTemplateVars _vars = AtTemplateVars(
   includeBundles: {'app'},
   dependencies: [
-    "at_client_mobile: ^3.0.3",
-    "at_utils: ^3.0.0",
+    "at_client_mobile: ^3.1.17",
+    "at_utils: ^3.0.10",
     "path_provider: ^2.0.5",
     "flutter_dotenv: ^5.0.2",
     "at_app_flutter: ^5.0.0"


### PR DESCRIPTION
Bumping the @platform packages to the newest. This will fix an issue with flutter_keychain (It's not used anymore)
there was a migration to the biometric_storage package... but the at_app cli was not referencing the newer versions of @platfrom packages
when creating a new app which leads to issues.